### PR TITLE
overlay: Disable SIM batch operations

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -186,4 +186,7 @@
 
     <!-- Allow the flashlight to use wakelocks -->
     <bool name="config_useWakeLockForFlashlight">true</bool>
+
+    <!-- Configuration to support SIM contact batch operation -->
+    <bool name="config_sim_phonebook_batch_operation">false</bool>
 </resources>


### PR DESCRIPTION
This feature appears to be unsupported, so disable it to allow
importing SIM contacts. Exporting contacts is not possible at
the moment without batch support.

Change-Id: I9477597876160dffa2b686d9376c623ddc0a9962